### PR TITLE
allow user to specify initial video fit

### DIFF
--- a/package/lib/src/controller.dart
+++ b/package/lib/src/controller.dart
@@ -79,7 +79,7 @@ class MeeduPlayerController {
   Rx<bool> bufferingVideoDuration = false.obs;
 
   Rx<bool> videoFitChanged = false.obs;
-  final Rx<BoxFit> _videoFit = Rx(BoxFit.fill);
+  final Rx<BoxFit> _videoFit;
   //Rx<double> scale = 1.0.obs;
   Rx<bool> rewindIcons = false.obs;
   Rx<bool> forwardIcons = false.obs;
@@ -282,7 +282,8 @@ class MeeduPlayerController {
     Responsive? responsive,
     this.durations = const Durations(),
     this.onVideoPlayerClosed,
-  }) {
+    BoxFit? initialFit,
+  }) : _videoFit = Rx(initialFit ?? BoxFit.fill) {
     if (responsive != null) {
       this.responsive = responsive;
     }
@@ -290,7 +291,10 @@ class MeeduPlayerController {
     if (!manageBrightness) {
       enabledControls = enabledControls.copyWith(brightnessSwipes: false);
     }
-    getUserPreferenceForFit();
+
+    if (initialFit == null) {
+      getUserPreferenceForFit();
+    }
 
     _errorText = errorText;
     tag = DateTime.now().microsecondsSinceEpoch.toString();


### PR DESCRIPTION
In this PR, I allow the user to specify initial fit of the video. Generally when no fit is set, `BoxFit.fill` is used by default. But in many cases users would want to use another BoxFit.